### PR TITLE
Update 2011-06-07-tags-in-jekyll.md

### DIFF
--- a/_posts/2011-06-07-tags-in-jekyll.md
+++ b/_posts/2011-06-07-tags-in-jekyll.md
@@ -64,9 +64,9 @@ In the tag_index file, put this:
         <time style="color:#666;font-size:11px;" datetime='{{post.date | date: "%Y-%m-%d"}}'>{{post.date | date: "%m/%d/%y"}}</time> <a class="archive_list_article_link" href='{{post.url}}'>{{post.title}}</a>
         <p class="summary">{{post.summary}}
         <ul class="tag_list">
-          {% for tag in post.tags %}
+          {.% for tag in post.tags %}
           <li class="inline archive_list"><a class="tag_list_link" href="/tag/{{ tag }}">{{ tag }}</a></li>
-          {% endfor %}
+          {.% endfor %}
         </ul>
       </li>
       {.% endif %}


### PR DESCRIPTION
These seem to not be showing up anymore, adding the period fixes it. https://charliepark.org/tags-in-jekyll